### PR TITLE
[IMP] Allow to specify the ref_mapping before loading

### DIFF
--- a/fast_alchemy/__init__.py
+++ b/fast_alchemy/__init__.py
@@ -321,7 +321,7 @@ class FastAlchemy:
                        file_or_raw,
                        auto_load=False,
                        instance_refs=None,
-                       ref_mapping={}):
+                       ref_mapping=None):
         classes = scan_current_models(self)
         self.class_registry.update(classes)
         raw_instances = self._load_file(file_or_raw)
@@ -332,6 +332,8 @@ class FastAlchemy:
             for k, v in raw_instances.items()
         }
 
+        if ref_mapping is None:
+            ref_mapping = {}
         for klass_name, definition in raw_instances.items():
             ref_mapping[klass_name.split('|')[0]] = definition['ref']
 

--- a/fast_alchemy/__init__.py
+++ b/fast_alchemy/__init__.py
@@ -317,7 +317,11 @@ class FastAlchemy:
             self._context_registry.update(registry)
         self.create_models(registry.keys())
 
-    def load_instances(self, file_or_raw, auto_load=False, instance_refs=None):
+    def load_instances(self,
+                       file_or_raw,
+                       auto_load=False,
+                       instance_refs=None,
+                       ref_mapping={}):
         classes = scan_current_models(self)
         self.class_registry.update(classes)
         raw_instances = self._load_file(file_or_raw)
@@ -328,7 +332,6 @@ class FastAlchemy:
             for k, v in raw_instances.items()
         }
 
-        ref_mapping = {}
         for klass_name, definition in raw_instances.items():
             ref_mapping[klass_name.split('|')[0]] = definition['ref']
 

--- a/tests/data/single_model.yaml
+++ b/tests/data/single_model.yaml
@@ -1,0 +1,16 @@
+AntColony:
+  ref: name
+  definition:
+    name: String
+    latin_name: String
+    queen_size: Float
+    worker_size: Float
+    color: String
+    formicarium: relationship|Formicarium
+  instances:
+    - name: Apomyrma
+      latin_name: Apomyrma stygia
+      queen_size: 1.2
+      worker_size: 1.2
+      color: yellow
+      formicarium: PAnts

--- a/tests/data/single_model.yaml
+++ b/tests/data/single_model.yaml
@@ -1,12 +1,5 @@
 AntColony:
   ref: name
-  definition:
-    name: String
-    latin_name: String
-    queen_size: Float
-    worker_size: Float
-    color: String
-    formicarium: relationship|Formicarium
   instances:
     - name: Apomyrma
       latin_name: Apomyrma stygia

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -87,8 +87,6 @@ def test_it_can_preloads_the_relations():
     session = sa.orm.scoped_session(Session)
 
     fa = FastAlchemy(Base, session)
-    with fa:
-        fa.load(os.path.join(DATA_DIR, 'instances.yaml'))
     fa.load(os.path.join(DATA_DIR, 'instances.yaml'))
     session.commit()
 

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -76,3 +76,23 @@ def test_it_can_export_models_to_python_code(temp_file):
     assert len(session.query(module.SandwichFormicarium).all()) == 3
     assert len(session.query(module.FreeStandingFormicarium).all()) == 2
     assert len(session.query(module.AntColony).all()) == 6
+
+
+def test_it_can_preloads_the_relations():
+    engine = sa.create_engine('sqlite:///:memory:')
+    Base = sa.ext.declarative.declarative_base()
+    Base.metadata.bind = engine
+    Session = sa.orm.sessionmaker(
+        autocommit=False, autoflush=False, bind=engine)
+    session = sa.orm.scoped_session(Session)
+
+    fa = FastAlchemy(Base, session)
+    with fa:
+        fa.load(os.path.join(DATA_DIR, 'instances.yaml'))
+    fa.load(os.path.join(DATA_DIR, 'instances.yaml'))
+    session.commit()
+
+    fa.load_instances(
+        os.path.join(DATA_DIR, 'single_model.yaml'),
+        auto_load=True,
+        ref_mapping={'Formicarium': 'name'})


### PR DESCRIPTION
This is necessary when you want to load instances from a single model
and don't want to specify all the related models in the same file.